### PR TITLE
Add option to put text at bottom of list instead of top

### DIFF
--- a/para/src/comp.php
+++ b/para/src/comp.php
@@ -75,6 +75,12 @@ $NEW_VALUE = $_REQUEST['NEW_VALUE'];
 echo "Paragraph text to use: " . $NEW_VALUE;
 echo "</br>";
 
+// does the paragraph go at the top or the bottom? (header or footer)
+$POSITION = $_REQUEST['POSITION'];
+
+echo "Paragraph text to use: " . $POSITION;
+echo "</br>";
+
 $shouldPublishLists = filter_var($_REQUEST['PUBLISH_LISTS'], FILTER_VALIDATE_BOOLEAN) || FALSE;
 
 echo "Should publish lists?: " . var_export($shouldPublishLists, true);
@@ -177,6 +183,8 @@ while (!feof($file_handle) )  {
 	$title = $output_json->data->attributes->title;
 	$listID = $output_json->data->id;
 	$etag = $output_json->data->meta->list_etag;
+	// positionIndex is the item count for footer (i.e. the next index) otherwise 0 (top)
+	$positionIndex = $POSITION == 'footer' ? $output_json->data->meta->item_count : 0;
 
 	echo "    Title: " . $title . "</br>";
 	fwrite($myfile, $title ."\t");
@@ -206,7 +214,7 @@ while (!feof($file_handle) )  {
 								"type": "lists"
 							},
 							"meta": {
-								"index": 0
+								"index":' . $positionIndex . '
 							}
 						}
 					}

--- a/para/src/para.html
+++ b/para/src/para.html
@@ -53,6 +53,13 @@
 					Input the desired text: <input name="NEW_VALUE" type ="text"/>
 					<br/>
 					<br/>
+					<label for="para_position">Where should this text be positioned in the list?</label>
+					<select name="POSITION" id="para_position">
+						<option value="header">header</option>
+						<option value="footer">footer</option>
+					</select>
+					<br/>
+					<br/>
 					Publish lists?: <select name="PUBLISH_LISTS">
 						<option selected="selected">FALSE</option>
 						<option>TRUE</option>


### PR DESCRIPTION
The existing 'para' functionality was set to add arbitrary HTML to a list, but only at index 0 - i.e. becoming the first item in the list.

This commit adds an HTML `<select>` field to choose between adding the text as a 'header' (existing functionality) or a 'footer'. We do this by grabbing the number of items in the list from the first call, and making that the index, since it's indexed at zero.

New variables in the php to enable this:

`$POSITION` - this is either 'header' or 'footer' and taken from the select field. Defaults to 'header' as per earlier behaviour.

`$positionIndex` - either equal to meta.item_count from the list (if position is 'footer' otherwise 0 as per earlier behaviour.

The final **PATCH** call to the API now uses `$positionIndex` for relationships.meta.index rather than the hard coded 0.