### PR TITLE
User config file include

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+user.config.php

--- a/README.md
+++ b/README.md
@@ -51,6 +51,13 @@ This guide will instruct you how to get these bulk tools working on a personal/w
 
 ## Running the tool
 
+- If this is your first time 
+  - make a copy of the `template.user.config.php` file and call it `user.config/php`
+  - Enter your Shortcode,
+  - Client ID,
+  - Client Secret
+  - and talis_guid user guid.
+  - Check with Talis Support if you don't know what any of these values should be
 - click on: http://localhost/bulk_tools-master/index.html
 - Follow steps on webform.
 - An example upload file is included as list_id.txt and looks like this (one list ID per line):
@@ -113,4 +120,4 @@ If you forget to make the change on the last operation, don't worry, as you can 
 ## Report Files
 
 - Report files are under the root folder of ./report_files and are separated by function.
-- If you extracted the tool to the suggestioned location in the above steps, this will be: c:\xampp\htdocs\bulk_tools-master\report_files\
+- If you extracted the tool to the suggested location in the above steps, this will be: c:\xampp\htdocs\bulk_tools-master\report_files\

--- a/del/src/comp.php
+++ b/del/src/comp.php
@@ -30,22 +30,16 @@ print_r($uploadfile);
 echo "</br>";
 echo "</br>";
 
-$shortCode = $_REQUEST['SHORT_CODE'];
+/**
+ * Get the user config file. This script will fail disgracefully if it has not been created and nothing will happen.
+ */
+require('../../user.config.php');
 
 echo "Tenancy Shortcode set: " . $shortCode;
 echo "</br>";
 
-$clientID = $_REQUEST['CLIENT_ID'];
-
 echo "Client ID set: " . $clientID;
 echo "</br>";
-
-$secret = $_REQUEST['CLIENT_SEC'];
-
-echo "Client secret set: " . $secret;
-echo "</br>";
-
-$TalisGUID = $_REQUEST['GUID'];
 
 echo "User GUID to use: " . $TalisGUID;
 echo "</br>";

--- a/del/src/del.html
+++ b/del/src/del.html
@@ -34,18 +34,8 @@
 					<form enctype="multipart/form-data" action="comp.php" method="POST">
 						<input type="hidden" name="MAX_FILE_SIZE" value="3000000" />
 						<h2>Configuration</h2>
-							Tenancy Short Code: <input name="SHORT_CODE" type ="text" size="12" />
-							<br/>
-							<br/>
-							Client ID: <input name="CLIENT_ID" type ="text" size="12" />
-							<br/>
-							<br/>
-							Client Secret: <input name="CLIENT_SEC" type ="text" size="20" />
-							<br/>
-							<br/>
-							Talis User GUID: <input name="GUID" type ="text" size="26" />
-							<br/>
-							<br/>
+						<p>If you have not created your own <code>user.config.php</code> file as a copy of the template in the project root directory do so now!!</p>
+						<p>Otherwise, this script will give you an error about not being able to find the <code>user.config.php</code> file.</p>
 						<h2>Rules</h2>
 						Send this file: <input name="userfile" type="file" />
 						Publish lists?: <select name="PUBLISH_LISTS">

--- a/index.html
+++ b/index.html
@@ -24,6 +24,9 @@
  <body>
 
 	<div class="links">
+		<h2>Configuration</h2>
+		<p>If you have not created your own <code>user.config.php</code> file as a copy of the template in the project root directory do so now!!</p>
+		<p>Otherwise, these scripts will give you an error about not being able to find the <code>user.config.php</code> file.</p>
 		<h2>Adding New Content</h2>
 		<a href="./para/src/para.html">Add a Paragraph </a></br>
 		<a href="./item/src/item.html">Add an Item </a></br>

--- a/item/src/comp.php
+++ b/item/src/comp.php
@@ -52,25 +52,18 @@ print_r($uploadfile);
 echo "</br>";
 echo "</br>";
 
-$shortCode = $_REQUEST['SHORT_CODE'];
+/**
+ * Get the user config file. This script will fail disgracefully if it has not been created and nothing will happen.
+ */
+require('../../user.config.php');
 
 echo "Tenancy Shortcode set: " . $shortCode;
 echo "</br>";
 
-$clientID = $_REQUEST['CLIENT_ID'];
-
 echo "Client ID set: " . $clientID;
 echo "</br>";
 
-$secret = $_REQUEST['CLIENT_SEC'];
-
-echo "Client secret set: " . $secret;
-echo "</br>";
-
-$TalisGUID = $_REQUEST['GUID'];
-
 echo "User GUID to use: " . $TalisGUID;
-echo "</br>";
 echo "</br>";
 
 

--- a/item/src/item.html
+++ b/item/src/item.html
@@ -41,18 +41,8 @@
 			<form enctype="multipart/form-data" action="comp.php" method="POST">
 				<input type="hidden" name="MAX_FILE_SIZE" value="3000000" />
 				<h2>Configuration</h2>
-					Tenancy Short Code: <input name="SHORT_CODE" type ="text" size="12" />
-					<br/>
-					<br/>
-					Client ID: <input name="CLIENT_ID" type ="text" size="12" />
-					<br/>
-					<br/>
-					Client Secret: <input name="CLIENT_SEC" type ="text" size="20" />
-					<br/>
-					<br/>
-					Talis User GUID: <input name="GUID" type ="text" size="26" />
-					<br/>
-					<br/>
+				<p>If you have not created your own <code>user.config.php</code> file as a copy of the template in the project root directory do so now!!</p>
+				<p>Otherwise, this script will give you an error about not being able to find the <code>user.config.php</code> file.</p>
 				<h2>Rules</h2>
 				Send this file: <input name="userfile" type="file" />
 					<br/>

--- a/para/src/comp.php
+++ b/para/src/comp.php
@@ -49,25 +49,18 @@ print_r($uploadfile);
 echo "</br>";
 echo "</br>";
 
-$shortCode = $_REQUEST['SHORT_CODE'];
+/**
+ * Get the user config file. This script will fail disgracefully if it has not been created and nothing will happen.
+ */
+require('../../user.config.php');
 
 echo "Tenancy Shortcode set: " . $shortCode;
 echo "</br>";
 
-$clientID = $_REQUEST['CLIENT_ID'];
-
 echo "Client ID set: " . $clientID;
 echo "</br>";
 
-$secret = $_REQUEST['CLIENT_SEC'];
-
-echo "Client secret set: " . $secret;
-echo "</br>";
-
-$TalisGUID = $_REQUEST['GUID'];
-
 echo "User GUID to use: " . $TalisGUID;
-echo "</br>";
 echo "</br>";
 
 $NEW_VALUE = $_REQUEST['NEW_VALUE'];

--- a/para/src/para.html
+++ b/para/src/para.html
@@ -34,18 +34,8 @@
 			<form enctype="multipart/form-data" action="comp.php" method="POST">
 				<input type="hidden" name="MAX_FILE_SIZE" value="3000000" />
 				<h2>Configuration</h2>
-					Tenancy Short Code: <input name="SHORT_CODE" type ="text" size="12" />
-					<br/>
-					<br/>
-					Client ID: <input name="CLIENT_ID" type ="text" size="12" />
-					<br/>
-					<br/>
-					Client Secret: <input name="CLIENT_SEC" type ="text" size="20" />
-					<br/>
-					<br/>
-					Talis User GUID: <input name="GUID" type ="text" size="26" />
-					<br/>
-					<br/>
+				<p>If you have not created your own <code>user.config.php</code> file as a copy of the template in the project root directory do so now!!</p>
+				<p>Otherwise, this script will give you an error about not being able to find the <code>user.config.php</code> file.</p>
 				<h2>Rules</h2>
 				Send this file: <input name="userfile" type="file" />
 					<br/>

--- a/publish/src/comp.php
+++ b/publish/src/comp.php
@@ -24,25 +24,18 @@ print_r($uploadfile);
 echo "</br>";
 echo "</br>";
 
-$shortCode = $_REQUEST['SHORT_CODE'];
+/**
+ * Get the user config file. This script will fail disgracefully if it has not been created and nothing will happen.
+ */
+require('../../user.config.php');
 
 echo "Tenancy Shortcode set: " . $shortCode;
 echo "</br>";
 
-$clientID = $_REQUEST['CLIENT_ID'];
-
 echo "Client ID set: " . $clientID;
 echo "</br>";
 
-$secret = $_REQUEST['CLIENT_SEC'];
-
-echo "Client secret set: " . $secret;
-echo "</br>";
-
-$TalisGUID = $_REQUEST['GUID'];
-
 echo "User GUID to use: " . $TalisGUID;
-echo "</br>";
 echo "</br>";
 
 //**********CREATE LOG FILE TO WRITE OUTPUT*

--- a/publish/src/publish.html
+++ b/publish/src/publish.html
@@ -39,18 +39,8 @@
 			<form enctype="multipart/form-data" action="comp.php" method="POST">
 				<input type="hidden" name="MAX_FILE_SIZE" value="3000000" />
 				<h2>Configuration</h2>
-					Tenancy Short Code: <input name="SHORT_CODE" type ="text" size="12" />
-					<br/>
-					<br/>
-					Client ID: <input name="CLIENT_ID" type ="text" size="12" />
-					<br/>
-					<br/>
-					Client Secret: <input name="CLIENT_SEC" type ="text" size="20" />
-					<br/>
-					<br/>
-					Talis User GUID: <input name="GUID" type ="text" size="26" />
-					<br/>
-					<br/>
+				<p>If you have not created your own <code>user.config.php</code> file as a copy of the template in the project root directory do so now!!</p>
+				<p>Otherwise, this script will give you an error about not being able to find the <code>user.config.php</code> file.</p>
 				<h2>Rules</h2>
 				Send this file: <input name="userfile" type="file" />
 					<br/>

--- a/recode/src/comp.php
+++ b/recode/src/comp.php
@@ -31,22 +31,16 @@ print_r($uploadfile);
 echo "</br>";
 echo "</br>";
 
-$shortCode = $_REQUEST['SHORT_CODE'];
+/**
+ * Get the user config file. This script will fail disgracefully if it has not been created and nothing will happen.
+ */
+require('../../user.config.php');
 
 echo "Tenancy Shortcode set: " . $shortCode;
 echo "</br>";
 
-$clientID = $_REQUEST['CLIENT_ID'];
-
 echo "Client ID set: " . $clientID;
 echo "</br>";
-
-$secret = $_REQUEST['CLIENT_SEC'];
-
-echo "Client secret set: " . $secret;
-echo "</br>";
-
-$TalisGUID = $_REQUEST['GUID'];
 
 echo "User GUID to use: " . $TalisGUID;
 echo "</br>";

--- a/recode/src/recode.html
+++ b/recode/src/recode.html
@@ -34,18 +34,8 @@
 					<form enctype="multipart/form-data" action="comp.php" method="POST">
 						<input type="hidden" name="MAX_FILE_SIZE" value="3000000" />
 						<h2>Configuration</h2>
-							Tenancy Short Code: <input name="SHORT_CODE" type ="text" size="12" />
-							<br/>
-							<br/>
-							Client ID: <input name="CLIENT_ID" type ="text" size="12" />
-							<br/>
-							<br/>
-							Client Secret: <input name="CLIENT_SEC" type ="text" size="20" />
-							<br/>
-							<br/>
-							Talis User GUID: <input name="GUID" type ="text" size="26" />
-							<br/>
-							<br/>
+						<p>If you have not created your own <code>user.config.php</code> file as a copy of the template in the project root directory do so now!!</p>
+						<p>Otherwise, this script will give you an error about not being able to find the <code>user.config.php</code> file.</p>
 						<h2>Rules</h2>
 						Send this file: <input name="userfile" type="file" />
 						<h2>Action</h2>

--- a/template.user.config.php
+++ b/template.user.config.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * This file contains user config. you can use this to set key's and secrets so that you don't have to set them elsewhere.
+ * 
+ * Make a copy of this template file and call it user.config.php.
+ * 
+ * Keep this copied file safe. 
+ * 
+ */
+
+/**
+ * The shortcode for your Talis Aspire tenancy
+ */
+$shortCode = '';
+
+/**
+ * The Client ID given to you by Talis Support
+ */
+$clientID = '';
+
+/**
+ * The Client Secret given to you by Talis Support
+ */
+$secret = '';
+
+/**
+ * A talis_guid to use for any requests which require the X-Effective-User header to be set.
+ * You will find this in the all users report CSV export.
+ */
+$TalisGUID = '';

--- a/url_complete/src/comp.php
+++ b/url_complete/src/comp.php
@@ -70,24 +70,20 @@ print_r($uploadfile);
 echo "</br>";
 echo "</br>";
 
+/**
+ * Get the user config file. This script will fail disgracefully if it has not been created and nothing will happen.
+ */
 require('../../user.config.php');
 
 echo "Tenancy Shortcode set: " . $shortCode;
 echo "</br>";
 
-
 echo "Client ID set: " . $clientID;
 echo "<br>";
-
-
-echo "Client secret set: " . $secret;
-echo "<br>";
-
 
 echo "User GUID to use: " . $TalisGUID;
 echo "<br>";
 echo "<br>";
-
 
 //**********CREATE LOG FILE TO WRITE OUTPUT*
 

--- a/url_complete/src/comp.php
+++ b/url_complete/src/comp.php
@@ -70,22 +70,19 @@ print_r($uploadfile);
 echo "</br>";
 echo "</br>";
 
-$shortCode = $_REQUEST['SHORT_CODE'];
+require('../../user.config.php');
 
 echo "Tenancy Shortcode set: " . $shortCode;
 echo "</br>";
 
-$clientID = $_REQUEST['CLIENT_ID'];
 
 echo "Client ID set: " . $clientID;
 echo "<br>";
 
-$secret = $_REQUEST['CLIENT_SEC'];
 
 echo "Client secret set: " . $secret;
 echo "<br>";
 
-$TalisGUID = $_REQUEST['GUID'];
 
 echo "User GUID to use: " . $TalisGUID;
 echo "<br>";

--- a/url_complete/src/url.html
+++ b/url_complete/src/url.html
@@ -37,18 +37,8 @@
 			<form enctype="multipart/form-data" action="comp.php" method="POST">
 				<input type="hidden" name="MAX_FILE_SIZE" value="3000000" />
 				<h2>Configuration</h2>
-					Tenancy Short Code: <input name="SHORT_CODE" type ="text" size="12" />
-					<br/>
-					<br/>
-					Client ID: <input name="CLIENT_ID" type ="text" size="12" />
-					<br/>
-					<br/>
-					Client Secret: <input name="CLIENT_SEC" type ="text" size="20" />
-					<br/>
-					<br/>
-					Talis User GUID: <input name="GUID" type ="text" size="26" />
-					<br/>
-					<br/>
+				<p>If you have not created your own <code>user.config.php</code> file as a copy of the template in the project root directory do so now!!</p>
+				<p>This script will give you an error about not being able to find the <code>user.config.php</code> file.</p>
 				<h2>Rules</h2>
 				Send this file: <input name="userfile" type="file" />
 					<br/>

--- a/url_complete/src/url.html
+++ b/url_complete/src/url.html
@@ -30,7 +30,7 @@
 </br><a href="../../index.html">Back to Index</a></br>
 
 <div id="TARL_bulk updater">
-		<h1>Bulk URL updater - Please attach a .txt file containing the following: (in order - tab seperated)</h1>
+		<h1>Bulk URL updater - Please attach a .txt file containing the following: (in order - comma seperated)</h1>
 			<li>Talis Item ID</li>
 			<li>Old/Current URL</li>
 			<li>New URL (to set)</li>
@@ -38,7 +38,7 @@
 				<input type="hidden" name="MAX_FILE_SIZE" value="3000000" />
 				<h2>Configuration</h2>
 				<p>If you have not created your own <code>user.config.php</code> file as a copy of the template in the project root directory do so now!!</p>
-				<p>This script will give you an error about not being able to find the <code>user.config.php</code> file.</p>
+				<p>Otherwise, this script will give you an error about not being able to find the <code>user.config.php</code> file.</p>
 				<h2>Rules</h2>
 				Send this file: <input name="userfile" type="file" />
 					<br/>

--- a/url_findreplace/src/comp.php
+++ b/url_findreplace/src/comp.php
@@ -122,7 +122,7 @@ while (!feof($file_handle) )  {
 
 $barc = trim($parts[0]);
 
-$item_lookup = "https://rl.talis.com/3/yorksj/draft_items/" . $barc;
+$item_lookup = "https://rl.talis.com/3/" . $shortCode . "/draft_items/" . $barc;
 $ch1 = curl_init();
 		
 		curl_setopt($ch1, CURLOPT_URL, $item_lookup);
@@ -158,7 +158,7 @@ $resourceID = $output_json->data->relationships->resource->data->id;
 
 	//************GET_URL_INFO***************
 
-$patch_url = "https://rl.talis.com/3/yorksj/resources/" . $resourceID;
+$patch_url = "https://rl.talis.com/3/" . $shortCode . "/resources/" . $resourceID;
 
 $ch3 = curl_init();
 		

--- a/url_findreplace/src/url.html
+++ b/url_findreplace/src/url.html
@@ -43,18 +43,8 @@
 			<form enctype="multipart/form-data" action="comp.php" method="POST">
 				<input type="hidden" name="MAX_FILE_SIZE" value="3000000" />
 				<h2>Configuration</h2>
-					Tenancy Short Code: <input name="SHORT_CODE" type ="text" size="12" />
-					<br/>
-					<br/>
-					Client ID: <input name="CLIENT_ID" type ="text" size="12" />
-					<br/>
-					<br/>
-					Client Secret: <input name="CLIENT_SEC" type ="text" size="20" />
-					<br/>
-					<br/>
-					Talis User GUID: <input name="GUID" type ="text" size="26" />
-					<br/>
-					<br/>
+				<p>If you have not created your own <code>user.config.php</code> file as a copy of the template in the project root directory do so now!!</p>
+				<p>Otherwise, this script will give you an error about not being able to find the <code>user.config.php</code> file.</p>
 				<h2>Rules</h2>
 				Send this file: <input name="userfile" type="file" />
 					<br/>


### PR DESCRIPTION
Refactored to pull user client and tenant details from a single file and not show secrets on screen.

This uses a `require()` php function which means that the code will fatally exit (and not do anything else) if the expected file is missing.

The file is missing until the user creates a copy of a template and configures it themselves the first time they use the tool. Instructions added to the readme also.